### PR TITLE
refactor: 채팅, 여행스타일 페이지 단계별로 컴포넌트화

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "react-slick": "^0.30.2",
     "slick-carousel": "^1.8.1",
     "styled-components": "^6.1.11",
-    "vite-plugin-svgr": "^4.2.0"
+    "vite-plugin-svgr": "^4.2.0",
+    "zustand": "^4.5.5"
   },
   "devDependencies": {
     "@tanstack/router-plugin": "^1.45.3",

--- a/src/components/chat/ChatGroup.tsx
+++ b/src/components/chat/ChatGroup.tsx
@@ -1,35 +1,17 @@
-import React, { Dispatch, PropsWithChildren, SetStateAction } from "react";
+import React, { PropsWithChildren } from "react";
 import styled from "styled-components";
 import { ChetSVG } from "../../assets";
-import type { ChatKind, Chat, Region } from "../../types";
-import Map from "./Map";
-import Button from "../common/Button";
-import DistrictGrid from "./DistrictGrid";
-import { Link } from "@tanstack/react-router";
+import type { Chat } from "../../types";
 
-interface ChatGroupProps extends Chat {
-  region: Region;
-  districtBooleans: boolean[];
-  setDistrictBooleans: Dispatch<SetStateAction<boolean[]>>;
-  mapHandler: (event: React.SyntheticEvent<SVGPathElement>) => void;
-  firstButtonHandler: () => void;
-}
+interface ChatGroupProps extends Chat {}
 
-function ChatGroup({
-  who,
-  kinds,
-  region,
-  districtBooleans,
-  mapHandler,
-  setDistrictBooleans,
-  firstButtonHandler,
-}: ChatGroupProps & PropsWithChildren) {
+function ChatGroup({ who, children }: ChatGroupProps & PropsWithChildren) {
   if (who == "user")
     return (
       <UserWrapper>
-        <ChatBoxContainer>
-          {kinds.map((kind) => (
-            <ChatBox type={who}>{kind.text}</ChatBox>
+        <ChatBoxContainer who={who}>
+          {React.Children.toArray(children).map((child) => (
+            <ChatBox who={who}>{child}</ChatBox>
           ))}
         </ChatBoxContainer>
       </UserWrapper>
@@ -38,43 +20,10 @@ function ChatGroup({
   return (
     <ChetWrapper>
       <ChetSVG height={100} />
-      <ChatBoxContainer>
-        {kinds.map((kind: ChatKind) => {
-          let content;
-          switch (kind.case) {
-            case 0:
-              content = kind.text;
-              break;
-            case 1:
-              content = <Map handleClick={mapHandler} />;
-              break;
-            case 2:
-              content = (
-                <DistrictGrid
-                  region={region}
-                  districtBooleans={districtBooleans}
-                  setDistrictBooleans={setDistrictBooleans}
-                />
-              );
-              break;
-            case 3:
-              content = (
-                <Button onClick={firstButtonHandler}>{kind.text}</Button>
-              );
-              break;
-            case 4:
-              content = (
-                <Button onClick={firstButtonHandler}>
-                  <Link to={"/style"}>{kind.text}</Link>
-                </Button>
-              );
-              break;
-            default:
-              content = <Button>{kind.text}</Button>;
-              break;
-          }
-          return <ChatBox type={who}>{content}</ChatBox>;
-        })}
+      <ChatBoxContainer who={who}>
+        {React.Children.toArray(children).map((child) => (
+          <ChatBox who={who}>{child}</ChatBox>
+        ))}
       </ChatBoxContainer>
     </ChetWrapper>
   );
@@ -99,20 +48,22 @@ const UserWrapper = styled.li`
   margin-right: 30px;
 `;
 
-const ChatBox = styled.div<{ type: "chet" | "user" }>`
-  background-color: ${({ type }) => (type == "chet" ? "#f5f5f5" : "#3B3B3B")};
-  color: ${({ type }) => (type == "chet" ? "black" : "white")};
+const ChatBox = styled.div<{ who: "chet" | "user" }>`
+  background-color: ${({ who }) => (who == "chet" ? "#f5f5f5" : "#3B3B3B")};
+  color: ${({ who }) => (who == "chet" ? "black" : "white")};
   border-radius: 20px;
   padding: 10px 15px;
   font-weight: 500;
   text-align: start;
   width: max-content;
-  white-space: break-spaces;
+  display: flex;
+  gap: 10px;
 `;
 
-const ChatBoxContainer = styled.div`
+const ChatBoxContainer = styled.div<{ who: "chet" | "user" }>`
   display: flex;
   flex-direction: column;
+  align-items: ${({ who }) => (who == "chet" ? "start" : "flex-end")};
+  margin: ${({ who }) => (who == "chet" ? "25px 0" : "0")};
   gap: 10px;
-  margin-top: 15px;
 `;

--- a/src/components/chat/ChatGroup.tsx
+++ b/src/components/chat/ChatGroup.tsx
@@ -58,6 +58,7 @@ const ChatBox = styled.div<{ who: "chet" | "user" }>`
   width: max-content;
   display: flex;
   gap: 10px;
+  max-width: 450px;
 `;
 
 const ChatBoxContainer = styled.div<{ who: "chet" | "user" }>`

--- a/src/components/chat/Districts.tsx
+++ b/src/components/chat/Districts.tsx
@@ -1,0 +1,57 @@
+import { useState } from "react";
+import { DISTRICT_MAP, REGION_MAP } from "../../constants";
+import { useChatStore, useTravelStore } from "../../stores";
+import { Region } from "../../types";
+import Button from "../common/Button";
+import ChatGroup from "./ChatGroup";
+import DistrictGrid from "./DistrictGrid";
+
+interface DistrictsProps {
+  region: Region;
+}
+const Districts = ({ region }: DistrictsProps) => {
+  const [districtBooleans, setDistrictBooleans] = useState(
+    Array(30).fill(false)
+  );
+  const next = useChatStore((state) => state.next);
+  const setDistricts = useTravelStore((state) => state.setDistricts);
+
+  const clickDone = () => {
+    if (region == null) return;
+    if (districtBooleans.every((x) => x == false)) return;
+
+    const selectedDistricts = DISTRICT_MAP[region].filter(
+      (_, index) => districtBooleans[index]
+    );
+    const newDistricts = districtBooleans.every((x) => x == true)
+      ? ["전체"]
+      : selectedDistricts;
+    setDistricts(newDistricts);
+    next();
+  };
+
+  return (
+    <>
+      <ChatGroup who={"user"}>
+        <p>{REGION_MAP[region]}로 떠나.</p>
+      </ChatGroup>
+      <ChatGroup who={"chet"}>
+        <p>
+          {REGION_MAP[region]}에서 특별히 여행하고 싶은 지역이 있다면 선택해줘!
+        </p>
+        <DistrictGrid
+          region={region}
+          districtBooleans={districtBooleans}
+          setDistrictBooleans={setDistrictBooleans}
+        />
+      </ChatGroup>
+      <ChatGroup who="user">
+        <Button design="secondary" onClick={clickDone}>
+          다 골랐어요
+        </Button>
+      </ChatGroup>
+    </>
+  );
+};
+
+export default Districts;

--- a/src/components/chat/Duration.tsx
+++ b/src/components/chat/Duration.tsx
@@ -1,0 +1,34 @@
+import Button from "../common/Button";
+import ChatGroup from "./ChatGroup";
+import { useChatStore, useTravelStore } from "../../stores";
+import { DURATIONS } from "../../constants";
+
+const Duration = () => {
+  const districts = useTravelStore((state) => state.districts);
+  const setDuration = useTravelStore((state) => state.setDuration);
+  const next = useChatStore((state) => state.next);
+
+  const clickDuration = (duration: number) => () => {
+    setDuration(duration);
+    next();
+  };
+
+  return (
+    <>
+      <ChatGroup who="chet">
+        <p>{districts.join(", ")}로 떠나는 구나! 여행 기간은 어떻게 돼?</p>
+      </ChatGroup>
+      <ChatGroup who="user">
+        <>
+          {DURATIONS.map((duration, index) => (
+            <Button design="secondary" onClick={clickDuration(index + 1)}>
+              {duration}
+            </Button>
+          ))}
+        </>
+      </ChatGroup>
+    </>
+  );
+};
+
+export default Duration;

--- a/src/components/chat/Map.tsx
+++ b/src/components/chat/Map.tsx
@@ -3,7 +3,7 @@ import { PinSVG } from "../../assets";
 import { useEffect, useRef, useState } from "react";
 import { REGION_MAP } from "../../constants";
 import { Region } from "../../types";
-import { isRegion } from "../../utils";
+import { isRegionType } from "../../utils";
 
 interface MapProps {
   handleClick: (event: React.SyntheticEvent<SVGPathElement>) => void;
@@ -13,7 +13,7 @@ const Map = ({ handleClick }: MapProps) => {
   const [hoveredRegion, setHoveredRegion] = useState<Region | null>(null);
 
   const handleMouseOver = (event: React.SyntheticEvent<SVGPathElement>) => {
-    if (isRegion(event.currentTarget.id)) {
+    if (isRegionType(event.currentTarget.id)) {
       setHoveredRegion(event.currentTarget.id);
     }
   };
@@ -187,6 +187,7 @@ const PinWrapper = styled.div`
 
 const Wrapper = styled.div`
   padding: 10px;
+
   & > svg {
     width: 100%;
     cursor: pointer;

--- a/src/components/chat/Preferences.tsx
+++ b/src/components/chat/Preferences.tsx
@@ -1,0 +1,92 @@
+import { useNavigate } from "@tanstack/react-router";
+import Button from "../common/Button";
+import ChatGroup from "./ChatGroup";
+import { useChatStore, useTravelStore } from "../../stores";
+import { memo } from "react";
+
+const STYLES = [
+  ["자연", "자연", "자연/도시", "도시", "도시"],
+  ["관광", "관광", "관광/휴식", "휴식", "휴식"],
+  ["럭셔리숙소", "럭셔리숙소", "숙박종류", "가성비숙소", "가성비숙소"],
+  [
+    "사진촬영 매우 중요",
+    "사진촬영 중요",
+    "사진촬영 상관없음",
+    "사진촬영을 딱히 중요하지 않음",
+    "사진촬영 매우 중요하지 않음",
+  ],
+];
+
+const STYLE_DESCRIPTIONS: Record<number, string> = {
+  1: "매우 선호",
+  2: "선호",
+  3: "상관없음",
+  4: "선호",
+  5: "매우 선호",
+};
+
+const Preferences = memo(() => {
+  const preferences = useTravelStore((store) => store.preferences);
+  const updatePreferences = useTravelStore((store) => store.updatePreferences);
+
+  const navigate = useNavigate();
+
+  const next = useChatStore((state) => state.next);
+
+  const resetStyle = () => {
+    localStorage.removeItem("preferences");
+    updatePreferences([0, 0, 0, 0]);
+    navigate({ to: "/style" });
+  };
+
+  const getStyleDescriptions = () => {
+    return preferences
+      .map((preference, index) => {
+        return index <= 2
+          ? STYLES[index][preference - 1] + " " + STYLE_DESCRIPTIONS[preference]
+          : STYLES[index][preference - 1];
+      })
+      .join(", ");
+  };
+
+  if (localStorage.getItem("preferences") && !localStorage.getItem("isFirst"))
+    return (
+      <>
+        <ChatGroup who="chet">
+          <p>여행 스타일은 그대로 할거야?</p>
+          <p>현재 스타일: {getStyleDescriptions()}</p>
+        </ChatGroup>
+        <ChatGroup who="user">
+          <>
+            <Button design="secondary" onClick={resetStyle}>
+              새로 고르기
+            </Button>
+            <Button design="secondary" onClick={() => next()}>
+              그대로
+            </Button>
+          </>
+        </ChatGroup>
+      </>
+    );
+
+  return (
+    <>
+      <ChatGroup who="chet">
+        <p>그렇구나! 이번 여행의 스타일을 알려줘!</p>
+      </ChatGroup>
+      <ChatGroup who="user">
+        <Button
+          design="secondary"
+          onClick={() => {
+            navigate({ to: "/style" });
+            localStorage.setItem("isFirst", "true");
+          }}
+        >
+          스타일 고르러 가기
+        </Button>
+      </ChatGroup>
+    </>
+  );
+});
+
+export default Preferences;

--- a/src/components/chat/Region.tsx
+++ b/src/components/chat/Region.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import ChatGroup from "./ChatGroup";
+import { isRegionType } from "../../utils";
+import { useChatStore, useTravelStore } from "../../stores";
+import Map from "./Map";
+
+const Region = () => {
+  const next = useChatStore((state) => state.next);
+  const setRegion = useTravelStore((state) => state.setRegion);
+
+  const clickRegion = (event: React.SyntheticEvent<SVGPathElement>) => {
+    if (isRegionType(event.currentTarget.id)) setRegion(event.currentTarget.id);
+    next();
+  };
+
+  return (
+    <ChatGroup who={"chet"}>
+      <p>
+        안녕! 나는 너만을 위한 여행 가이드, 체트라고 해.
+        <br />
+        이번 여행은 어디로 떠나? 지도에 영역을 클릭해줘!
+      </p>
+      <Map handleClick={clickRegion} />
+    </ChatGroup>
+  );
+};
+
+export default Region;

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -30,7 +30,7 @@ const Wrapper = styled.button<{ design: ButtonProps["design"] }>`
   line-height: 34px;
   border-radius: 30px;
   font-size: 16px;
-  font-weight: 500;
+  font-weight: 550;
   &:hover {
     transform: scale(1.02);
   }

--- a/src/components/common/Funnel.tsx
+++ b/src/components/common/Funnel.tsx
@@ -1,0 +1,4 @@
+export interface FunnelProps {
+  onNext: () => void;
+  onPrev?: () => void;
+}

--- a/src/components/style/StyleSlide.tsx
+++ b/src/components/style/StyleSlide.tsx
@@ -1,12 +1,11 @@
-// import { useState } from "react";
 import styled from "styled-components";
 
-interface StyleSlideProps {
+export interface StyleSlideProps {
   title: string;
   preference: number;
   images: string[];
   descriptions: string[];
-  changeHandler: (newPreference: number) => () => void;
+  onChange: (data: number) => () => void;
 }
 
 const StyleSlide = ({
@@ -14,7 +13,7 @@ const StyleSlide = ({
   preference,
   images,
   descriptions,
-  changeHandler,
+  onChange,
 }: StyleSlideProps) => {
   return (
     <Wrapper>
@@ -31,7 +30,7 @@ const StyleSlide = ({
               name="radio"
               type="radio"
               checked={preference == 0 ? false : preference == index + 1}
-              onChange={changeHandler(index + 1)}
+              onChange={onChange(index + 1)}
             />
             <RadioButtonLabel />
           </RadioGroup>

--- a/src/components/style/관광휴식.tsx
+++ b/src/components/style/관광휴식.tsx
@@ -1,0 +1,61 @@
+import { useState } from "react";
+import StyleSlide from "./StyleSlide";
+import { ResortJPG, TourJPG } from "../../assets";
+import { FunnelProps } from "../common/Funnel";
+import Button from "../common/Button";
+import styled from "styled-components";
+import { useTravelStore, TravelStore } from "../../stores";
+
+const 관광휴식 = ({ onNext, onPrev }: FunnelProps) => {
+  const preferences = useTravelStore((state) => state.preferences);
+  const updatePreferences = useTravelStore(
+    (state: TravelStore) => state.updatePreferences
+  );
+
+  const [preference, setPreference] = useState(preferences[1]);
+
+  const changePreference = (newPreference: number) => () => {
+    setPreference(newPreference);
+  };
+
+  const savePreferences = () => {
+    const newPreferences = [...preferences];
+    newPreferences[1] = preference;
+
+    updatePreferences(newPreferences);
+  };
+
+  return (
+    <>
+      <StyleSlide
+        title="관광 vs 휴식"
+        preference={preference}
+        images={[TourJPG, ResortJPG]}
+        descriptions={["관광이 목적이에요", "휴식을 취하러 가요"]}
+        onChange={changePreference}
+      />
+      <ButtonWrapper>
+        <Button onClick={onPrev}>이전</Button>
+        <Button
+          onClick={() => {
+            savePreferences();
+            onNext();
+          }}
+        >
+          다음
+        </Button>
+      </ButtonWrapper>
+    </>
+  );
+};
+
+const ButtonWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  position: fixed;
+  bottom: 10%;
+  width: 40%;
+  right: 30%;
+`;
+
+export default 관광휴식;

--- a/src/components/style/사진.tsx
+++ b/src/components/style/사진.tsx
@@ -1,0 +1,61 @@
+import { useState } from "react";
+import { HatePhotoJPG, LikePhotoJPG } from "../../assets";
+import Button from "../common/Button";
+import { FunnelProps } from "../common/Funnel";
+import StyleSlide from "./StyleSlide";
+import styled from "styled-components";
+import { useTravelStore, TravelStore } from "../../stores";
+
+const 사진 = ({ onNext, onPrev }: FunnelProps) => {
+  const preferences = useTravelStore((state) => state.preferences);
+  const updatePreferences = useTravelStore(
+    (state: TravelStore) => state.updatePreferences
+  );
+
+  const [preference, setPreference] = useState(preferences[3]);
+
+  const changePreference = (newPreference: number) => () => {
+    setPreference(newPreference);
+  };
+
+  const savePreferences = () => {
+    const newPreferences = [...preferences];
+    newPreferences[3] = preference;
+
+    updatePreferences(newPreferences);
+  };
+
+  return (
+    <>
+      <StyleSlide
+        title="사진촬영 중요 vs 안 중요"
+        preference={preference}
+        images={[LikePhotoJPG, HatePhotoJPG]}
+        descriptions={["포토스팟을 원해요", "사진에 관심없어요"]}
+        onChange={changePreference}
+      />
+      <ButtonWrapper>
+        <Button onClick={onPrev}>이전</Button>
+        <Button
+          onClick={() => {
+            savePreferences();
+            onNext();
+          }}
+        >
+          다음
+        </Button>
+      </ButtonWrapper>
+    </>
+  );
+};
+
+const ButtonWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  position: fixed;
+  bottom: 10%;
+  width: 40%;
+  right: 30%;
+`;
+
+export default 사진;

--- a/src/components/style/사진.tsx
+++ b/src/components/style/사진.tsx
@@ -4,15 +4,17 @@ import Button from "../common/Button";
 import { FunnelProps } from "../common/Funnel";
 import StyleSlide from "./StyleSlide";
 import styled from "styled-components";
-import { useTravelStore, TravelStore } from "../../stores";
+import { useTravelStore, TravelStore, useChatStore } from "../../stores";
 
 const 사진 = ({ onNext, onPrev }: FunnelProps) => {
   const preferences = useTravelStore((state) => state.preferences);
+  const [preference, setPreference] = useState(preferences[3]);
+
   const updatePreferences = useTravelStore(
     (state: TravelStore) => state.updatePreferences
   );
 
-  const [preference, setPreference] = useState(preferences[3]);
+  const nextChatStep = useChatStore((state) => state.next);
 
   const changePreference = (newPreference: number) => () => {
     setPreference(newPreference);
@@ -40,6 +42,7 @@ const 사진 = ({ onNext, onPrev }: FunnelProps) => {
           onClick={() => {
             savePreferences();
             onNext();
+            nextChatStep();
           }}
         >
           다음

--- a/src/components/style/숙박.tsx
+++ b/src/components/style/숙박.tsx
@@ -1,0 +1,61 @@
+import { useState } from "react";
+import { ExpensiveJPG, CheapJPG } from "../../assets";
+import Button from "../common/Button";
+import { FunnelProps } from "../common/Funnel";
+import StyleSlide from "./StyleSlide";
+import styled from "styled-components";
+import { useTravelStore, TravelStore } from "../../stores";
+
+const 숙박 = ({ onNext, onPrev }: FunnelProps) => {
+  const preferences = useTravelStore((state) => state.preferences);
+  const updatePreferences = useTravelStore(
+    (state: TravelStore) => state.updatePreferences
+  );
+
+  const [preference, setPreference] = useState(preferences[2]);
+
+  const changePreference = (newPreference: number) => () => {
+    setPreference(newPreference);
+  };
+
+  const savePreferences = () => {
+    const newPreferences = [...preferences];
+    newPreferences[2] = preference;
+
+    updatePreferences(newPreferences);
+  };
+
+  return (
+    <>
+      <StyleSlide
+        title="럭셔리숙소 vs 가성비숙소"
+        preference={preference}
+        images={[ExpensiveJPG, CheapJPG]}
+        descriptions={["호캉스가 좋아요", "잠만 자도 괜찮아요"]}
+        onChange={changePreference}
+      />
+      <ButtonWrapper>
+        <Button onClick={onPrev}>이전</Button>
+        <Button
+          onClick={() => {
+            savePreferences();
+            onNext();
+          }}
+        >
+          다음
+        </Button>
+      </ButtonWrapper>
+    </>
+  );
+};
+
+const ButtonWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  position: fixed;
+  bottom: 10%;
+  width: 40%;
+  right: 30%;
+`;
+
+export default 숙박;

--- a/src/components/style/자연도시.tsx
+++ b/src/components/style/자연도시.tsx
@@ -8,11 +8,11 @@ import styled from "styled-components";
 
 const 자연도시 = ({ onNext }: FunnelProps) => {
   const preferences = useTravelStore((state) => state.preferences);
+  const [preference, setPreference] = useState(preferences[0]);
+
   const updatePreferences = useTravelStore(
     (state: TravelStore) => state.updatePreferences
   );
-
-  const [preference, setPreference] = useState(preferences[0]);
 
   const changePreference = (newPreference: number) => () => {
     setPreference(newPreference);
@@ -21,7 +21,6 @@ const 자연도시 = ({ onNext }: FunnelProps) => {
   const savePreferences = () => {
     const newPreferences = [...preferences];
     newPreferences[0] = preference;
-
     updatePreferences(newPreferences);
   };
 

--- a/src/components/style/자연도시.tsx
+++ b/src/components/style/자연도시.tsx
@@ -1,0 +1,60 @@
+import { useState } from "react";
+import StyleSlide from "./StyleSlide";
+import { CityJPG, NatureJPG } from "../../assets";
+import { FunnelProps } from "../common/Funnel";
+import Button from "../common/Button";
+import { useTravelStore, TravelStore } from "../../stores";
+import styled from "styled-components";
+
+const 자연도시 = ({ onNext }: FunnelProps) => {
+  const preferences = useTravelStore((state) => state.preferences);
+  const updatePreferences = useTravelStore(
+    (state: TravelStore) => state.updatePreferences
+  );
+
+  const [preference, setPreference] = useState(preferences[0]);
+
+  const changePreference = (newPreference: number) => () => {
+    setPreference(newPreference);
+  };
+
+  const savePreferences = () => {
+    const newPreferences = [...preferences];
+    newPreferences[0] = preference;
+
+    updatePreferences(newPreferences);
+  };
+
+  return (
+    <>
+      <StyleSlide
+        title="자연 vs 도시"
+        preference={preference}
+        images={[NatureJPG, CityJPG]}
+        descriptions={[
+          "자연 속에서 힐링하고 싶어요",
+          "시끌벅적한 도심 속이 좋아요",
+        ]}
+        onChange={changePreference}
+      />
+      <ButtonWrapper>
+        <Button
+          onClick={() => {
+            savePreferences();
+            onNext();
+          }}
+        >
+          다음
+        </Button>
+      </ButtonWrapper>
+    </>
+  );
+};
+
+const ButtonWrapper = styled.div`
+  position: fixed;
+  bottom: 10%;
+  right: 30%;
+`;
+
+export default 자연도시;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,3 +1,5 @@
+export const DURATIONS = ["당일치기", "1박2일", "2박3일", "3박4일"];
+
 export const REGION_MAP = {
   "seoul-si": "서울",
   "gyeonggi-do": "경기도",

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,35 +1,3 @@
-import {
-  NatureJPG,
-  CityJPG,
-  TourJPG,
-  ResortJPG,
-  ExpensiveJPG,
-  CheapJPG,
-  LikePhotoJPG,
-  HatePhotoJPG,
-} from "../assets";
-
-export const TITLES = [
-  "자연 vs 도시",
-  "관광 vs 휴식",
-  "편하지만 비싼 숙소 vs 불편하지만 저렴한 숙소",
-  "사진촬영 중요 vs 안 중요",
-];
-
-export const IMAGES = [
-  [NatureJPG, CityJPG],
-  [TourJPG, ResortJPG],
-  [ExpensiveJPG, CheapJPG],
-  [LikePhotoJPG, HatePhotoJPG],
-];
-
-export const DESCRIPTIONS = [
-  ["자연 속에서 힐링하고 싶어요", "시끌벅적한 도심 속이 좋아요"],
-  ["관광이 목적이에요", "휴식을 취하러 가요"],
-  ["숙소 값은 비싸도 상관없어요", "숙소 값은 쌀수록 좋아요"],
-  ["포토스팟을 원해요", "사진 찍는 것에 관심없어요"],
-];
-
 export const REGION_MAP = {
   "seoul-si": "서울",
   "gyeonggi-do": "경기도",

--- a/src/index.css
+++ b/src/index.css
@@ -13,6 +13,10 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
+p {
+  margin: 0;
+}
+
 a {
   font-weight: 500;
   color: #232323;

--- a/src/routes/chat.tsx
+++ b/src/routes/chat.tsx
@@ -1,105 +1,187 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import styled from "styled-components";
 import ChatGroup from "../components/chat/ChatGroup";
-import type { Chat, ChatWho, Region } from "../types";
+import type { Chat } from "../types";
 import { useEffect, useRef, useState } from "react";
-import { isRegion } from "../utils";
+import { isRegionType } from "../utils";
 import { DISTRICT_MAP, REGION_MAP } from "../constants";
 import PageTemplate from "../components/common/PageTemplate";
+import Map from "../components/chat/Map";
+import DistrictGrid from "../components/chat/DistrictGrid";
+import Button from "../components/common/Button";
+import { useChatStore, useTravelStore } from "../stores";
+
+const DURATIONS = ["당일치기", "1박2일", "2박3일", "3박4일"];
 
 export const Route = createFileRoute("/chat")({
-  // loader: fetchPosts,
+  // loader: fetchChats,
   component: Chat,
 });
 
 function Chat() {
-  const clickRegion = (event: React.SyntheticEvent<SVGPathElement>) => {
-    if (isRegion(event.currentTarget.id)) {
-      setRegion(event.currentTarget.id);
-      const secondOnboardingChat = [
-        {
-          who: "user" as ChatWho,
-          kinds: [
-            { case: 0, text: `${REGION_MAP[event.currentTarget.id]}로 떠나.` },
-          ],
-        },
-        {
-          who: "chet" as ChatWho,
-          kinds: [
-            {
-              case: 0,
-              text: `${REGION_MAP[event.currentTarget.id]}에서 특별히 여행하고 싶은 지역이 있다면 선택해줘!`,
-            },
-            { case: 2 },
-            { case: 3, text: "다 골랐어요" },
-          ],
-        },
-      ];
-      setChats(chats.concat(secondOnboardingChat));
-    }
-  };
-
-  const firstOnboardingChat = {
-    who: "chet" as ChatWho,
-    kinds: [
-      {
-        case: 0,
-        text: "안녕! 나는 너만을 위한 여행 가이드, 체트라고 해.\n이번 여행은 어디로 떠나? 지도에 영역을 클릭해줘!",
-      },
-      { case: 1 },
-    ],
-  };
-  const [chats, setChats] = useState<Chat[]>([firstOnboardingChat]);
-  const [region, setRegion] = useState<Region | null>(null);
+  const navigate = useNavigate();
   const ChatListRef = useRef<HTMLUListElement>(null);
+  // const [chats, setChats] = useState<Chat[]>([]);
+
+  const step = useChatStore((state) => state.step);
+  const next = useChatStore((state) => state.next);
+  const reset = useChatStore((state) => state.reset);
+  const region = useTravelStore((state) => state.region);
+  const setRegion = useTravelStore((state) => state.setRegion);
+  const duration = useTravelStore((state) => state.duration);
+  const setDuration = useTravelStore((state) => state.setDuration);
+  const districts = useTravelStore((state) => state.districts);
+  const setDistricts = useTravelStore((state) => state.setDistricts);
   const [districtBooleans, setDistrictBooleans] = useState(
     Array(30).fill(false)
   );
 
-  const clickDone = () => {
-    if (region == null) return;
+  const getDistricts = () => {
+    if (region == null) return [];
+    if (districtBooleans.every((x) => x == false)) return [];
 
     const selectedDistricts = DISTRICT_MAP[region].filter(
       (_, index) => districtBooleans[index]
     );
-    const textedDistricts = districtBooleans.every((x) => x == true)
-      ? `${REGION_MAP[region]} 전체`
-      : selectedDistricts.join(", ");
 
-    const thirdOnboardingChat = [
-      {
-        who: "user" as ChatWho,
-        kinds: [{ case: 0, text: `${textedDistricts}` }],
-      },
-      {
-        who: "chet" as ChatWho,
-        kinds: [
-          {
-            case: 0,
-            text: `그렇구나! 이번 여행의 스타일을 알려줘!`,
-          },
-          { case: 4, text: "스타일 고르러가기" },
-        ],
-      },
-    ];
-    setChats(chats.concat(thirdOnboardingChat));
+    return districtBooleans.every((x) => x == true)
+      ? ["전체"]
+      : selectedDistricts;
+  };
+
+  const clickRegion = (event: React.SyntheticEvent<SVGPathElement>) => {
+    if (isRegionType(event.currentTarget.id)) setRegion(event.currentTarget.id);
+    next();
+  };
+
+  const clickDone = () => {
+    if (region == null) return;
+    setDistricts(getDistricts());
+    next();
+  };
+
+  const clickStyle = () => {
+    navigate({ to: "/style" });
+    next();
+  };
+
+  const clickDuration = (duration: number) => () => {
+    setDuration(duration);
+    next();
+  };
+
+  const resetCourse = () => {
+    reset();
+    localStorage.removeItem("region");
+    localStorage.removeItem("preferences");
+    localStorage.removeItem("duration");
   };
 
   useEffect(() => {
     if (ChatListRef.current) {
-      if (chats.length == 1) return;
+      if (step == 1) {
+        ChatListRef.current.scrollTo({
+          top: 0,
+          behavior: "smooth",
+        });
+        return;
+      }
+
+      if (step == 5) {
+        ChatListRef.current.scrollTo({
+          top: ChatListRef.current.scrollHeight,
+        });
+        return;
+      }
 
       ChatListRef.current.scrollTo({
         top: ChatListRef.current.scrollHeight,
         behavior: "smooth",
       });
     }
-  }, [chats]);
+  }, [step]);
 
   return (
     <PageTemplate pageName="Chat" badgeText="Chat with Chet!">
+      <ResetButtonWrapper>
+        <Button design="secondary" onClick={resetCourse}>
+          + 새 여행코스
+        </Button>
+      </ResetButtonWrapper>
       <ChatList ref={ChatListRef}>
-        {chats.map((chat) => (
+        {step >= 1 && (
+          <ChatGroup who={"chet"}>
+            <p>
+              안녕! 나는 너만을 위한 여행 가이드, 체트라고 해.
+              <br />
+              이번 여행은 어디로 떠나? 지도에 영역을 클릭해줘!
+            </p>
+            <Map handleClick={clickRegion} />
+          </ChatGroup>
+        )}
+        {step >= 2 && region && (
+          <>
+            <ChatGroup who={"user"}>
+              <p>{REGION_MAP[region]}로 떠나.</p>
+            </ChatGroup>
+            <ChatGroup who={"chet"}>
+              <p>
+                {REGION_MAP[region]}에서 특별히 여행하고 싶은 지역이 있다면
+                선택해줘!
+              </p>
+              <DistrictGrid
+                region={region}
+                districtBooleans={districtBooleans}
+                setDistrictBooleans={setDistrictBooleans}
+              />
+            </ChatGroup>
+            <ChatGroup who="user">
+              <Button design="secondary" onClick={clickDone}>
+                다 골랐어요
+              </Button>
+              {step >= 3 && <p>{districts.join(", ")}로 떠나.</p>}
+            </ChatGroup>
+          </>
+        )}
+        {step >= 3 && (
+          <>
+            <ChatGroup who="chet">
+              <p>여행 기간은 어떻게 돼?</p>
+            </ChatGroup>
+            <ChatGroup who="user">
+              <>
+                {DURATIONS.map((duration, index) => (
+                  <Button design="secondary" onClick={clickDuration(index + 1)}>
+                    {duration}
+                  </Button>
+                ))}
+              </>
+            </ChatGroup>
+          </>
+        )}
+        {step >= 4 && (
+          <>
+            <ChatGroup who="chet">
+              <p>그렇구나! 이번 여행의 스타일을 알려줘!</p>
+            </ChatGroup>
+            <ChatGroup who="user">
+              <Button design="secondary" onClick={clickStyle}>
+                스타일 고르러 가기
+              </Button>
+            </ChatGroup>
+          </>
+        )}
+        {step >= 5 && region && (
+          <>
+            <ChatGroup who="chet">
+              <p>
+                너만을 위한 {REGION_MAP[region]} {DURATIONS[duration - 1]}{" "}
+                여행코스를 생성 중이야! <br /> 잠시만 기다려줘~
+              </p>
+            </ChatGroup>
+          </>
+        )}
+        {/* {chats.map((chat) => (
           <ChatGroup
             who={chat.who}
             kinds={chat.kinds}
@@ -109,7 +191,7 @@ function Chat() {
             mapHandler={clickRegion}
             firstButtonHandler={clickDone}
           />
-        ))}
+        ))} */}
       </ChatList>
     </PageTemplate>
   );
@@ -120,20 +202,25 @@ const ChatList = styled.ul`
   margin-right: auto;
 
   width: 50vw;
-  height: 70vh;
+  height: 600px;
   overflow: scroll;
   display: flex;
   flex-direction: column;
   list-style-type: none;
-  gap: 20px;
-  padding-bottom: 10vh;
   box-sizing: border-box;
+  padding-bottom: 100px;
 
   @media screen and (width <= 500px) {
     padding-top: 100px;
     width: 100vw;
     padding-left: 15px;
   }
+`;
+
+const ResetButtonWrapper = styled.div`
+  position: absolute;
+  top: 28%;
+  left: 5%;
 `;
 
 export default Chat;

--- a/src/routes/chat.tsx
+++ b/src/routes/chat.tsx
@@ -1,17 +1,16 @@
-import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { createFileRoute } from "@tanstack/react-router";
 import styled from "styled-components";
 import ChatGroup from "../components/chat/ChatGroup";
 import type { Chat } from "../types";
-import { useEffect, useRef, useState } from "react";
-import { isRegionType } from "../utils";
-import { DISTRICT_MAP, REGION_MAP } from "../constants";
+import { useEffect, useRef } from "react";
+import { DURATIONS, REGION_MAP } from "../constants";
 import PageTemplate from "../components/common/PageTemplate";
-import Map from "../components/chat/Map";
-import DistrictGrid from "../components/chat/DistrictGrid";
 import Button from "../components/common/Button";
 import { useChatStore, useTravelStore } from "../stores";
-
-const DURATIONS = ["당일치기", "1박2일", "2박3일", "3박4일"];
+import Region from "../components/chat/Region";
+import Districts from "../components/chat/Districts";
+import Duration from "../components/chat/Duration";
+import Preferences from "../components/chat/Preferences";
 
 export const Route = createFileRoute("/chat")({
   // loader: fetchChats,
@@ -19,62 +18,21 @@ export const Route = createFileRoute("/chat")({
 });
 
 function Chat() {
-  const navigate = useNavigate();
   const ChatListRef = useRef<HTMLUListElement>(null);
   // const [chats, setChats] = useState<Chat[]>([]);
 
   const step = useChatStore((state) => state.step);
-  const next = useChatStore((state) => state.next);
-  const reset = useChatStore((state) => state.reset);
   const region = useTravelStore((state) => state.region);
-  const setRegion = useTravelStore((state) => state.setRegion);
   const duration = useTravelStore((state) => state.duration);
-  const setDuration = useTravelStore((state) => state.setDuration);
-  const districts = useTravelStore((state) => state.districts);
-  const setDistricts = useTravelStore((state) => state.setDistricts);
-  const [districtBooleans, setDistrictBooleans] = useState(
-    Array(30).fill(false)
-  );
 
-  const getDistricts = () => {
-    if (region == null) return [];
-    if (districtBooleans.every((x) => x == false)) return [];
-
-    const selectedDistricts = DISTRICT_MAP[region].filter(
-      (_, index) => districtBooleans[index]
-    );
-
-    return districtBooleans.every((x) => x == true)
-      ? ["전체"]
-      : selectedDistricts;
-  };
-
-  const clickRegion = (event: React.SyntheticEvent<SVGPathElement>) => {
-    if (isRegionType(event.currentTarget.id)) setRegion(event.currentTarget.id);
-    next();
-  };
-
-  const clickDone = () => {
-    if (region == null) return;
-    setDistricts(getDistricts());
-    next();
-  };
-
-  const clickStyle = () => {
-    navigate({ to: "/style" });
-    next();
-  };
-
-  const clickDuration = (duration: number) => () => {
-    setDuration(duration);
-    next();
-  };
+  const reset = useChatStore((state) => state.reset);
 
   const resetCourse = () => {
     reset();
     localStorage.removeItem("region");
-    localStorage.removeItem("preferences");
     localStorage.removeItem("duration");
+    localStorage.removeItem("districts");
+    localStorage.removeItem("isFirst");
   };
 
   useEffect(() => {
@@ -109,68 +67,10 @@ function Chat() {
         </Button>
       </ResetButtonWrapper>
       <ChatList ref={ChatListRef}>
-        {step >= 1 && (
-          <ChatGroup who={"chet"}>
-            <p>
-              안녕! 나는 너만을 위한 여행 가이드, 체트라고 해.
-              <br />
-              이번 여행은 어디로 떠나? 지도에 영역을 클릭해줘!
-            </p>
-            <Map handleClick={clickRegion} />
-          </ChatGroup>
-        )}
-        {step >= 2 && region && (
-          <>
-            <ChatGroup who={"user"}>
-              <p>{REGION_MAP[region]}로 떠나.</p>
-            </ChatGroup>
-            <ChatGroup who={"chet"}>
-              <p>
-                {REGION_MAP[region]}에서 특별히 여행하고 싶은 지역이 있다면
-                선택해줘!
-              </p>
-              <DistrictGrid
-                region={region}
-                districtBooleans={districtBooleans}
-                setDistrictBooleans={setDistrictBooleans}
-              />
-            </ChatGroup>
-            <ChatGroup who="user">
-              <Button design="secondary" onClick={clickDone}>
-                다 골랐어요
-              </Button>
-              {step >= 3 && <p>{districts.join(", ")}로 떠나.</p>}
-            </ChatGroup>
-          </>
-        )}
-        {step >= 3 && (
-          <>
-            <ChatGroup who="chet">
-              <p>여행 기간은 어떻게 돼?</p>
-            </ChatGroup>
-            <ChatGroup who="user">
-              <>
-                {DURATIONS.map((duration, index) => (
-                  <Button design="secondary" onClick={clickDuration(index + 1)}>
-                    {duration}
-                  </Button>
-                ))}
-              </>
-            </ChatGroup>
-          </>
-        )}
-        {step >= 4 && (
-          <>
-            <ChatGroup who="chet">
-              <p>그렇구나! 이번 여행의 스타일을 알려줘!</p>
-            </ChatGroup>
-            <ChatGroup who="user">
-              <Button design="secondary" onClick={clickStyle}>
-                스타일 고르러 가기
-              </Button>
-            </ChatGroup>
-          </>
-        )}
+        {step >= 1 && <Region />}
+        {step >= 2 && region && <Districts region={region} />}
+        {step >= 3 && <Duration />}
+        {step >= 4 && <Preferences />}
         {step >= 5 && region && (
           <>
             <ChatGroup who="chet">

--- a/src/routes/info.tsx
+++ b/src/routes/info.tsx
@@ -12,3 +12,267 @@ function Info() {
 }
 
 export default Info;
+
+// import Header from "@components/Header";
+// import { useState } from "react";
+// import useBoolean from "../hooks/useBoolean";
+// import styled from "styled-components";
+
+// const TERMS = ["1시간", "2시간", "3시간", "4시간", "5시간", "6시간", "7시간"];
+
+// const ParkingLotFilterCondition = () => {
+//   const outside = useBoolean();
+//   const road = useBoolean();
+//   const mechanical = useBoolean();
+//   const publicParkingLot = useBoolean();
+//   const privateParkingLot = useBoolean();
+//   const charged = useBoolean();
+//   const free = useBoolean();
+//   const account = useBoolean();
+//   const cash = useBoolean();
+//   const card = useBoolean();
+//   const distance = useBoolean();
+//   const price = useBoolean();
+//   const recommend = useBoolean();
+
+//   return (
+//     <Wrapper>
+//       <Header />
+//       <Title>
+//         <h1>주차장 조건설정</h1>
+//         <p>선호하는 주차장 유형을 알려주세요!</p>
+//       </Title>
+//       <Line $height="7px" />
+//       <ConditionList>
+//         <ConditionContainer>
+//           <h2>주차장 유형</h2>
+//           <p>원하시는 주차장을 선택해주세요!</p>
+//           <FilterContainer>
+//             <FilterButton
+//               $width="81px"
+//               $checked={outside.value}
+//               onClick={outside.toggle}
+//             >
+//               노외
+//             </FilterButton>
+//             <FilterButton
+//               $width="81px"
+//               $checked={road.value}
+//               onClick={road.toggle}
+//             >
+//               노상
+//             </FilterButton>
+//             <FilterButton
+//               $width="81px"
+//               $checked={mechanical.value}
+//               onClick={mechanical.toggle}
+//             >
+//               기계식
+//             </FilterButton>
+//           </FilterContainer>
+//         </ConditionContainer>
+//         <Line $height="2px" />
+//         <ConditionContainer>
+//           <h2>주차장 옵션</h2>
+//           <p>원하시는 주차장을 선택해주세요!</p>
+//           <FilterContainer>
+//             <FilterButton
+//               $width="155px"
+//               $checked={publicParkingLot.value}
+//               onClick={publicParkingLot.toggle}
+//             >
+//               공영
+//             </FilterButton>
+//             <FilterButton
+//               $width="155px"
+//               $checked={privateParkingLot.value}
+//               onClick={privateParkingLot.toggle}
+//             >
+//               민영
+//             </FilterButton>
+//           </FilterContainer>
+//         </ConditionContainer>
+//         <Line $height="2px" />
+//         <ConditionContainer>
+//           <h2>주차장 결제 유형</h2>
+//           <p>원하시는 주차장 결제 유형을 골라주세요!</p>
+//           <FilterContainer>
+//             <FilterButton
+//               $width="155px"
+//               $checked={charged.value}
+//               onClick={charged.toggle}
+//             >
+//               유료
+//             </FilterButton>
+//             <FilterButton
+//               $width="155px"
+//               $checked={free.value}
+//               onClick={free.toggle}
+//             >
+//               무료
+//             </FilterButton>
+//           </FilterContainer>
+//         </ConditionContainer>
+//         <Line $height="2px" />
+//         <ConditionContainer>
+//           <h2>결제 방식</h2>
+//           <p>유료를 선택하셨다면, 선호하는 결제방식을 골라주세요!</p>
+//           <FilterContainer>
+//             <FilterButton
+//               $width="81px"
+//               $checked={account.value}
+//               onClick={account.toggle}
+//             >
+//               계좌
+//             </FilterButton>
+//             <FilterButton
+//               $width="81px"
+//               $checked={cash.value}
+//               onClick={cash.toggle}
+//             >
+//               현금
+//             </FilterButton>
+//             <FilterButton
+//               $width="81px"
+//               $checked={card.value}
+//               onClick={card.toggle}
+//             >
+//               카드
+//             </FilterButton>
+//           </FilterContainer>
+//         </ConditionContainer>
+//         <Line $height="2px" />
+//         <ConditionContainer>
+//           <h2>우선순위 주차장</h2>
+//           <p>우선 순위로 보고 싶은 주차장을 골라주세요! (중복 선택 불가)</p>
+//           <FilterContainer>
+//             <FilterButton
+//               $width="81px"
+//               $checked={distance.value}
+//               onClick={distance.toggle}
+//             >
+//               가까운 순
+//             </FilterButton>
+//             <FilterButton
+//               $width="81px"
+//               $checked={price.value}
+//               onClick={price.toggle}
+//             >
+//               가격순
+//             </FilterButton>
+//             <FilterButton
+//               $width="81px"
+//               $checked={recommend.value}
+//               onClick={recommend.toggle}
+//             >
+//               추천순
+//             </FilterButton>
+//           </FilterContainer>
+//         </ConditionContainer>
+//         <SaveButton>저장하기</SaveButton>
+//       </ConditionList>
+//     </Wrapper>
+//   );
+// };
+
+// const SaveButton = styled.button`
+//   width: 90%;
+//   padding: 0.6em 1.2em;
+//   margin-top: 20px;
+//   margin-bottom: 100px;
+
+//   background: #bdc4cb;
+//   border-radius: 10px;
+
+//   color: white;
+//   font-size: 20px;
+//   font-weight: 700;
+//   font-family: inherit;
+// `;
+
+// const Wrapper = styled.div`
+//   width: 100%;
+//   height: 100vh;
+// `;
+
+// const Title = styled.div`
+//   text-align: start;
+//   padding: 10px 0 20px 20px;
+
+//   & > h1 {
+//     font-size: 20px;
+//     font-weight: bold;
+//   }
+
+//   & > p {
+//     margin-top: 10px;
+//   }
+// `;
+
+// const Line = styled.div<{ $height: string }>`
+//   width: 100%;
+//   height: ${({ $height }) => $height};
+
+//   background-color: #f6f6f6;
+// `;
+
+// const ConditionList = styled.section`
+//   height: calc(100% - 184px);
+//   overflow: scroll;
+// `;
+
+// const ConditionContainer = styled.section`
+//   text-align: start;
+//   padding: 20px;
+
+//   & > h2 {
+//     font-size: 16px;
+//     font-weight: 600;
+//   }
+
+//   & > p {
+//     margin-top: 5px;
+
+//     color: #bdc4cb;
+//   }
+// `;
+
+// const FilterContainer = styled.div`
+//   display: flex;
+//   width: 100%;
+//   margin-top: 16px;
+//   justify-content: space-between;
+// `;
+
+// const FilterButton = styled.button<{ $width: string; $checked?: boolean }>`
+//   display: flex;
+//   width: ${(props) => props.$width};
+//   height: 35px;
+//   padding: 0;
+//   justify-content: center;
+//   align-items: center;
+
+//   background-color: ${(props) => (props.$checked ? "#D9D9D9" : "white")};
+//   border: solid 1px #bdc4cb;
+//   border-radius: 20px;
+
+//   color: ${(props) => (props.$checked ? "white" : "#bdc4cb")};
+//   gap: 5px;
+
+//   & > svg > * {
+//     stroke: ${(props) => (props.$checked ? "white" : "#bdc4cb")};
+//   }
+// `;
+
+// const ElectricCar = styled.div`
+//   display: flex;
+//   padding-top: 20px;
+//   justify-content: space-between;
+
+//   & > h3 {
+//     font-size: 16px;
+//     font-weight: 400;
+//   }
+// `;
+
+// export default ParkingLotFilterCondition;

--- a/src/routes/style.tsx
+++ b/src/routes/style.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, Link } from "@tanstack/react-router";
 import styled from "styled-components";
 import PageTemplate from "../components/common/PageTemplate";
 import StyleSlide from "../components/style/StyleSlide";
@@ -45,7 +45,11 @@ function Style() {
           ))}
         </Slider>
         <ButtonWrapper>
-          {isDone() && <Button>스타일 저장하기</Button>}
+          {isDone() && (
+            <Button>
+              <Link to={"/chat"}>스타일 저장하기</Link>
+            </Button>
+          )}
         </ButtonWrapper>
       </SliderWrapper>
     </PageTemplate>

--- a/src/routes/style.tsx
+++ b/src/routes/style.tsx
@@ -1,68 +1,50 @@
-import { createFileRoute, Link } from "@tanstack/react-router";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import styled from "styled-components";
 import PageTemplate from "../components/common/PageTemplate";
-import StyleSlide from "../components/style/StyleSlide";
 import { useState } from "react";
-import Slider from "react-slick";
-import Button from "../components/common/Button";
-import { TITLES, IMAGES, DESCRIPTIONS } from "../constants";
+import 자연도시 from "../components/style/자연도시";
+import 관광휴식 from "../components/style/관광휴식";
+import 숙박 from "../components/style/숙박";
+import 사진 from "../components/style/사진";
 
 export const Route = createFileRoute("/style")({
   component: Style,
 });
 
 function Style() {
-  const [preferences, setPreferences] = useState([0, 0, 0, 0]);
-  const [slideIndex, setSlideIndex] = useState(0);
-
-  const sliderSettings = {
-    infinite: false,
-    slidesToShow: 1,
-    slidesToScroll: 1,
-    cssEase: "linear",
-    afterChange: (index: number) => setSlideIndex(index),
-  };
-
-  const changePreference = (newPreference: number) => () => {
-    preferences[slideIndex] = newPreference;
-    setPreferences([...preferences]);
-  };
-
-  const isDone = () => preferences.every((x) => x != 0);
+  const navigate = useNavigate();
+  const [step, setStep] = useState<"자연도시" | "관광휴식" | "숙박" | "사진">(
+    "자연도시"
+  );
 
   return (
     <PageTemplate pageName="Style" badgeText="Choose your style!">
       <SliderWrapper>
-        <Slider {...sliderSettings}>
-          {preferences.map((_, index) => (
-            <StyleSlide
-              title={TITLES[index]}
-              preference={preferences[index]}
-              images={IMAGES[index]}
-              descriptions={DESCRIPTIONS[index]}
-              changeHandler={changePreference}
-            />
-          ))}
-        </Slider>
-        <ButtonWrapper>
-          {isDone() && (
-            <Button>
-              <Link to={"/chat"}>스타일 저장하기</Link>
-            </Button>
-          )}
-        </ButtonWrapper>
+        {step == "자연도시" && <자연도시 onNext={() => setStep("관광휴식")} />}
+        {step == "관광휴식" && (
+          <관광휴식
+            onNext={() => setStep("숙박")}
+            onPrev={() => setStep("자연도시")}
+          />
+        )}
+        {step == "숙박" && (
+          <숙박
+            onNext={() => setStep("사진")}
+            onPrev={() => setStep("관광휴식")}
+          />
+        )}
+        {step == "사진" && (
+          <사진
+            onNext={() => navigate({ to: "/chat", replace: true })}
+            onPrev={() => setStep("숙박")}
+          />
+        )}
       </SliderWrapper>
     </PageTemplate>
   );
 }
 
 export default Style;
-
-const ButtonWrapper = styled.div`
-  position: absolute;
-  right: 0;
-  bottom: 30px;
-`;
 
 const SliderWrapper = styled.div`
   margin-left: auto;

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -1,0 +1,13 @@
+import { create } from "zustand";
+
+export const useStore = create((set) => ({
+  bears: 0,
+  preferences: [],
+  updatePreferences: (newPreferences: number[]) => {
+    set({ preferences: newPreferences });
+    localStorage.setItem("preferences", JSON.stringify(newPreferences)); // localStorage에 저장
+  },
+  // increasePopulation: () => set((state) => ({ bears: state.bears + 1 })),
+  // removeAllBears: () => set({ bears: 0 }),
+  // updateBears: (newBears) => set({ bears: newBears }),
+}));

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -1,13 +1,58 @@
 import { create } from "zustand";
+import { Region } from "../types";
 
-export const useStore = create((set) => ({
-  bears: 0,
-  preferences: [],
+export interface TravelStore {
+  region: Region | null;
+  setRegion: (region: Region) => void;
+  preferences: number[];
+  updatePreferences: (newPreferences: number[]) => void;
+  duration: number;
+  setDuration: (duration: number) => void;
+  districts: string[];
+  setDistricts: (districts: string[]) => void;
+}
+
+export const useTravelStore = create<TravelStore>((set) => ({
+  region: JSON.parse(localStorage.getItem("region") || "null"),
+  preferences: JSON.parse(
+    localStorage.getItem("preferences") || "[0, 0, 0, 0]"
+  ),
+  duration: JSON.parse(localStorage.getItem("duration") || "0"),
+  districts: JSON.parse(localStorage.getItem("districts") || "[]"),
+  setRegion: (region: Region) => {
+    set({ region });
+    localStorage.setItem("region", JSON.stringify(region));
+  },
   updatePreferences: (newPreferences: number[]) => {
     set({ preferences: newPreferences });
-    localStorage.setItem("preferences", JSON.stringify(newPreferences)); // localStorage에 저장
+    localStorage.setItem("preferences", JSON.stringify(newPreferences));
   },
-  // increasePopulation: () => set((state) => ({ bears: state.bears + 1 })),
-  // removeAllBears: () => set({ bears: 0 }),
-  // updateBears: (newBears) => set({ bears: newBears }),
+  setDuration: (duration: number) => {
+    set({ duration });
+    localStorage.setItem("duration", JSON.stringify(duration));
+  },
+  setDistricts: (districts: string[]) => {
+    set({ districts });
+    localStorage.setItem("districts", JSON.stringify(districts));
+  },
+}));
+
+export interface ChatStore {
+  step: number;
+  next: () => void;
+  reset: () => void;
+}
+
+export const useChatStore = create<ChatStore>((set) => ({
+  step: JSON.parse(localStorage.getItem("step") || "1"),
+  next: () => {
+    set((state) => {
+      const newStep = state.step + 1;
+      localStorage.setItem("step", JSON.stringify(newStep));
+      return { step: newStep };
+    });
+  },
+  reset: () => {
+    set({ step: 1 });
+  },
 }));

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -54,5 +54,6 @@ export const useChatStore = create<ChatStore>((set) => ({
   },
   reset: () => {
     set({ step: 1 });
+    localStorage.setItem("step", JSON.stringify(1));
   },
 }));

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -12,7 +12,7 @@ export type ChatWho = "chet" | "user";
 
 export interface Chat {
   who: ChatWho;
-  kinds: ChatKind[];
+  kinds?: ChatKind[];
 }
 
 export interface ChatKind {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,5 @@
 import { REGION_MAP } from "../constants";
 import { Region } from "../types";
 
-export const isRegion = (x: string): x is Region =>
+export const isRegionType = (x: string): x is Region =>
   Object.keys(REGION_MAP).includes(x);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2285,7 +2285,7 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
-use-sync-external-store@^1.2.2:
+use-sync-external-store@1.2.2, use-sync-external-store@^1.2.2:
   version "1.2.2"
   resolved "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz#c3b6390f3a30eba13200d2302dcdf1e7b57b2ef9"
   integrity sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==
@@ -2351,3 +2351,10 @@ zod@^3.23.8:
   version "3.23.8"
   resolved "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz#e37b957b5d52079769fb8097099b592f0ef4067d"
   integrity sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==
+
+zustand@^4.5.5:
+  version "4.5.5"
+  resolved "https://registry.npmjs.org/zustand/-/zustand-4.5.5.tgz#f8c713041543715ec81a2adda0610e1dc82d4ad1"
+  integrity sha512-+0PALYNJNgK6hldkgDq2vLrw5f6g/jCInz52n9RTpropGgeAf/ioFUCdtsjCqu4gNhW9D01rUQBROoRjdzyn2Q==
+  dependencies:
+    use-sync-external-store "1.2.2"


### PR DESCRIPTION
[변경사항]
1. 여행정보페이지가 사라짐에 따라, 채팅 온보딩에서 여행 기간을 입력받기로 함.
2. react-slick 오류(화살 커스텀 어려움, 전체 레이아웃 깨짐, 슬라이딩시 버벅거림)가 너무 많아서 없애고 funnel 패턴 적용
3. 비로그인 유저들을 위해 로컬스토리지로 새로고침해도 여행 정보 저장되게끔 구현